### PR TITLE
Ncurses: update to latest master

### DIFF
--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="ncurses"
-PKG_VERSION="6.0-20170812"
+PKG_VERSION="6.0-20171007"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
With the reintroduction of ncurses (version 20170812), i noticed artifacts especially using mc over ssh. Building version 20171007 i no longer notice these artifacts, so i think it's safe to update the package.mk (Caution, i tested only with mc 4.8.19 on two different openSUSE desktops connected via ssh to my htpc)